### PR TITLE
ci(backend): update SonarCloud scan action

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -35,9 +35,8 @@ jobs:
       - name: Run tests
         run: yarn test --coverage --testResultsProcessor jest-sonar-reporter
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4
         with:
           projectBaseDir: backend
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.BACKEND_SONAR_TOKEN }}


### PR DESCRIPTION
Replace SonarSource/sonarcloud-github-action with
SonarSource/sonarqube-scan-action@v4 for improved scanning capabilities. Remove GITHUB_TOKEN as it's no longer required for the new action. This change enhances our code quality analysis process.